### PR TITLE
Simplify calibration using reference images

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -31,10 +31,14 @@ installation directory to the `PATH` environment variable. On macOS you can run
    window.
 
 3. **Capture templates (optional but recommended)**
-   - Option `2` records additional close buttons (`X`). Click directly on each
-     `X` you want to save; press `Q` when done.
-   - Option `3` captures button templates for the `+200 monedas` CTA. Click on
-     the button inside the calibration preview.
+   - Option `2` now imports ready-made captures of the close button (`X`). Place
+     the reference image(s) inside `templates/reference/` (for example the
+     screenshot containing `X/Continuar/Recompensa en X segundos`) and provide
+     the path when prompted. The helper copies them into the working templates
+     folder without opening an extra window.
+   - Option `3` works the same way for the `+200 monedas por ver un anuncio`
+     button: point the prompt to the supplied screenshot and the bot will store
+     grayscale templates automatically.
 
 4. **Start the bot**
    - From the interactive menu choose option `4`.

--- a/tests/test_calibration_utils.py
+++ b/tests/test_calibration_utils.py
@@ -1,6 +1,18 @@
 """Unit tests for calibration utility helpers."""
 
-from calibration_utils import compute_display_scale, map_display_to_image_coords
+import os
+from pathlib import Path
+
+import pytest
+
+cv2 = pytest.importorskip("cv2")
+np = pytest.importorskip("numpy")
+
+from calibration_utils import (
+    compute_display_scale,
+    import_reference_templates,
+    map_display_to_image_coords,
+)
 
 
 def test_compute_display_scale_limits_window_size():
@@ -24,4 +36,44 @@ def test_map_display_to_image_coords_invalid_scale():
         assert "scale" in str(exc)
     else:
         raise AssertionError("Expected ValueError for zero scale")
+
+
+def _create_sample_image(path: Path, color: tuple[int, int, int]) -> str:
+    image = np.full((20, 30, 3), color, dtype=np.uint8)
+    cv2.putText(image, "X", (5, 15), cv2.FONT_HERSHEY_SIMPLEX, 0.5,
+                (255, 255, 255), 1, cv2.LINE_AA)
+    cv2.imwrite(str(path), image)
+    return str(path)
+
+
+def test_import_reference_templates_creates_grayscale(tmp_path):
+    source = _create_sample_image(tmp_path / "x.png", (0, 0, 255))
+    destination = tmp_path / "templates"
+
+    saved = import_reference_templates([source], str(destination), "x_template")
+
+    assert saved == ["x_template_1.png"]
+
+    stored = cv2.imread(str(destination / saved[0]), cv2.IMREAD_UNCHANGED)
+    assert stored is not None
+    # Grayscale images have two dimensions
+    assert stored.ndim == 2
+
+
+def test_import_reference_templates_respects_existing_index(tmp_path):
+    destination = tmp_path / "templates"
+    os.makedirs(destination, exist_ok=True)
+
+    # Pre-create an existing template with index 4
+    existing = destination / "x_template_4.png"
+    _create_sample_image(existing, (0, 255, 0))
+
+    src1 = _create_sample_image(tmp_path / "money1.png", (255, 0, 0))
+    src2 = _create_sample_image(tmp_path / "money2.png", (0, 255, 255))
+
+    saved = import_reference_templates(
+        [src1, src2], str(destination), "x_template"
+    )
+
+    assert saved == ["x_template_5.png", "x_template_6.png"]
 


### PR DESCRIPTION
## Summary
- replace the interactive calibration flows with a file-based workflow that imports the provided reference screenshots
- add reusable helpers to normalise reference images and expand the calibration unit tests
- document the updated instructions for loading the X and +200 monedas templates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d568eba4dc83288df17a83455d9e9a